### PR TITLE
feat(Velocity): ability to track velocity of OVRCameraRig objects - fixes #2

### DIFF
--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ccbe6f1b25a565147a7e5e57e02cf196
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c0477faf83091e544bbb3a8b2aec557f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts.meta
+++ b/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b25dc9c813d01634bb8e64a3a666ecf1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking.meta
+++ b/Scripts/Tracking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2cffc6e2f7fb762448c2dc8fcc8502fe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Velocity.meta
+++ b/Scripts/Tracking/Velocity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 01a523529584f7f44bbab1eb67d3640c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Velocity/VelocityEstimator.cs
+++ b/Scripts/Tracking/Velocity/VelocityEstimator.cs
@@ -1,0 +1,59 @@
+﻿namespace VRTK.OculusUtilities.Tracking.Velocity
+{
+    using UnityEngine;
+    using VRTK.Core.Tracking.Velocity;
+
+    /// <summary>
+    /// The VelocityEstimator retrieves the velocity and angular velocity from the specific named OVRCameraRig tracked anchor (CenterEyeAnchor, LeftHandAnchor, RightHandAnchor).
+    /// </summary>
+    public class VelocityEstimator : VelocityTracker
+    {
+        [Tooltip("The GameObject anchor from the OVRCameraRig to track velocity for.")]
+        public GameObject trackedGameObject;
+
+        /// <summary>
+        /// The IsActive method returns the state of whether the component is active.
+        /// </summary>
+        /// <returns>Returns `true` if the component is considered active.</returns>
+        public override bool IsActive()
+        {
+            return (trackedGameObject != null && trackedGameObject.activeInHierarchy && isActiveAndEnabled);
+        }
+
+        /// <summary>
+        /// The GetVelocity method returns the velocity of the tracked object.
+        /// </summary>
+        /// <returns>A Vector3 of the current tracked velocity.</returns>
+        public override Vector3 GetVelocity()
+        {
+            switch (trackedGameObject.name)
+            {
+                case "CenterEyeAnchor":
+                    return (OVRManager.isHmdPresent ? OVRPlugin.GetNodeVelocity(OVRPlugin.Node.EyeCenter, OVRPlugin.Step.Render).FromFlippedZVector3f() : Vector3.zero);
+                case "LeftHandAnchor":
+                    return OVRInput.GetLocalControllerVelocity(OVRInput.Controller.LTouch);
+                case "RightHandAnchor":
+                    return OVRInput.GetLocalControllerVelocity(OVRInput.Controller.RTouch);
+            }
+            return Vector3.zero;
+        }
+
+        /// <summary>
+        /// The GetAngularVelocityMethod returns the angular velocity of the tracked object.
+        /// </summary>
+        /// <returns>A Vector3 of the current tracked angular velocity.</returns>
+        public override Vector3 GetAngularVelocity()
+        {
+            switch (trackedGameObject.name)
+            {
+                case "CenterEyeAnchor":
+                    return (OVRManager.isHmdPresent ? OVRPlugin.GetNodeAngularVelocity(OVRPlugin.Node.EyeCenter, OVRPlugin.Step.Render).FromFlippedZVector3f() : Vector3.zero);
+                case "LeftHandAnchor":
+                    return OVRInput.GetLocalControllerAngularVelocity(OVRInput.Controller.LTouch);
+                case "RightHandAnchor":
+                    return OVRInput.GetLocalControllerAngularVelocity(OVRInput.Controller.RTouch);
+            }
+            return Vector3.zero;
+        }
+    }
+}

--- a/Scripts/Tracking/Velocity/VelocityEstimator.cs.meta
+++ b/Scripts/Tracking/Velocity/VelocityEstimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b6b40b21e438eb4d9935c402ad9c550
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Velocity Estimator script allows velocity tracking of the following
OVRCameraRig objects:

 * CenterEyeAnchor
 * LeftHandAnchor
 * RightHandAnchor

And is limited to tracking only the Oculus Touch controllers which
are currently the only things that report a velocity.