### PR TITLE
fix(Input): ensure right touch controller is set to primary

### DIFF
--- a/Prefabs/InputMappings/Oculus.Rift.RightTouchMap.prefab
+++ b/Prefabs/InputMappings/Oculus.Rift.RightTouchMap.prefab
@@ -37,7 +37,7 @@ GameObject:
   - component: {fileID: 114331647316959178}
   - component: {fileID: 114491034666237436}
   m_Layer: 0
-  m_Name: SecondaryHandTrigger
+  m_Name: PrimaryHandTrigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -73,7 +73,7 @@ GameObject:
   - component: {fileID: 114927100388940030}
   - component: {fileID: 114292176769005110}
   m_Layer: 0
-  m_Name: SecondaryIndexTrigger
+  m_Name: PrimaryIndexTrigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -91,7 +91,7 @@ GameObject:
   - component: {fileID: 114801384479876790}
   - component: {fileID: 114122500885717852}
   m_Layer: 0
-  m_Name: SecondaryThumbstick
+  m_Name: PrimaryThumbstick
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -124,7 +124,7 @@ GameObject:
   - component: {fileID: 4608729619114730}
   - component: {fileID: 114044495754234096}
   m_Layer: 0
-  m_Name: SecondaryThumbRest
+  m_Name: PrimaryThumbRest
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -255,7 +255,7 @@ MonoBehaviour:
     m_TypeName: VRTK.Core.Action.BooleanAction+UnityEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   controller: 2
-  touch: 1048576
+  touch: 4096
 --- !u!114 &114057569513564136
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -343,7 +343,7 @@ MonoBehaviour:
       Culture=neutral, PublicKeyToken=null
   equalityTolerance: 1e-45
   controller: 2
-  axis: 2
+  axis: 1
 --- !u!114 &114280666501185498
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -372,7 +372,7 @@ MonoBehaviour:
     m_TypeName: VRTK.Core.Action.BooleanAction+UnityEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   controller: 2
-  touch: 8388608
+  touch: 32768
 --- !u!114 &114292176769005110
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -402,7 +402,7 @@ MonoBehaviour:
       Culture=neutral, PublicKeyToken=null
   equalityTolerance: 1e-45
   controller: 2
-  axis: 2
+  axis: 1
 --- !u!114 &114331647316959178
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -431,7 +431,7 @@ MonoBehaviour:
     m_TypeName: VRTK.Core.Action.BooleanAction+UnityEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   controller: 2
-  button: 4194304
+  button: 16384
 --- !u!114 &114491034666237436
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -461,7 +461,7 @@ MonoBehaviour:
       Culture=neutral, PublicKeyToken=null
   equalityTolerance: 1e-45
   controller: 2
-  axis: 8
+  axis: 4
 --- !u!114 &114516270273887522
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -519,7 +519,7 @@ MonoBehaviour:
     m_TypeName: VRTK.Core.Action.BooleanAction+UnityEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   controller: 2
-  touch: 2097152
+  touch: 8192
 --- !u!114 &114598607088469046
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -548,7 +548,7 @@ MonoBehaviour:
     m_TypeName: VRTK.Core.Action.BooleanAction+UnityEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   controller: 2
-  nearTouch: 4
+  nearTouch: 1
 --- !u!114 &114689061850769628
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -606,7 +606,7 @@ MonoBehaviour:
     m_TypeName: VRTK.Core.Action.BooleanAction+UnityEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   controller: 2
-  button: 8388608
+  button: 32768
 --- !u!114 &114927100388940030
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -635,4 +635,4 @@ MonoBehaviour:
     m_TypeName: VRTK.Core.Action.BooleanAction+UnityEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   controller: 2
-  button: 2097152
+  button: 8192


### PR DESCRIPTION
Because the Oculus Input Action types use the OVRInput virtual
methods, it means any reference to the controller type is always
primary. Secondary is only ever used when referencing other controllers
such as the Xbox Gamepad or when using the OVRInput raw methods.

The prefab has been updated to the correct type now.