### PR TITLE
chore(Velocity): rename velocity estimator to more specific name

### DIFF
--- a/Scripts/Tracking/Velocity/OVRAnchorVelocityEstimator.cs
+++ b/Scripts/Tracking/Velocity/OVRAnchorVelocityEstimator.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Retrieves the velocity and angular velocity from the specific named OVRCameraRig tracked anchor (CenterEyeAnchor, LeftHandAnchor, RightHandAnchor).
     /// </summary>
-    public class VelocityEstimator : VelocityTracker
+    public class OVRAnchorVelocityEstimator : VelocityTracker
     {
         /// <summary>
         /// The <see cref="GameObject"/> anchor from the OVRCameraRig to track velocity for.

--- a/Scripts/Tracking/Velocity/OVRAnchorVelocityEstimator.cs.meta
+++ b/Scripts/Tracking/Velocity/OVRAnchorVelocityEstimator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5b6b40b21e438eb4d9935c402ad9c550
+guid: 09b41ed4bec23bf4198099d2a437b98c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
The Oculus Velocity Estimator isn't a generic estimator as it is
specifically tied to the OVRCameraRig Anchor points to get the
velocities for objects of that type.

Therefore, it's more appropriate to name it around what it's actually
doing and this lends itself better to determining what the component
actually does.