### PR TITLE
feat(Tracking): determine controller type - resolves #3

### DIFF
--- a/Scripts/Association.meta
+++ b/Scripts/Association.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b2237ee868f6f746ad1331b5f475edf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Association/OculusControllerAssociation.cs
+++ b/Scripts/Association/OculusControllerAssociation.cs
@@ -1,0 +1,30 @@
+﻿namespace VRTK.OculusUtilities.Association
+{
+    using UnityEngine;
+    using VRTK.Core.Association;
+
+    /// <summary>
+    /// Holds <see cref="GameObject"/>s to (de)activate based on a <see cref="OVRInput.Controller"/>.
+    /// </summary>
+    public class OculusControllerAssociation : BaseGameObjectsAssociation
+    {
+        /// <summary>
+        /// The <see cref="OVRInput.Controller"/> that needs to be connected.
+        /// </summary>
+        [Tooltip("The OVRInput.Controller that needs to be connected.")]
+        public OVRInput.Controller controller = OVRInput.Controller.None;
+
+        /// <summary>
+        /// Whether the <see cref="controller"/> needs to be active.
+        /// </summary>
+        [Tooltip("Whether the controller needs to be active.")]
+        public bool needsToBeActive;
+
+        /// <inheritdoc />
+        public override bool ShouldBeActive()
+        {
+            return OVRInput.IsControllerConnected(controller)
+                && ((OVRInput.GetActiveController() == controller) == needsToBeActive);
+        }
+    }
+}

--- a/Scripts/Association/OculusControllerAssociation.cs.meta
+++ b/Scripts/Association/OculusControllerAssociation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c3e32ef9869f4244a14fb30d1e599142
+timeCreated: 1531660391


### PR DESCRIPTION
A new type has been added to allow turning on/off game objects based
on whether a specific type of controller is currently connected or
additionally the active controller.